### PR TITLE
chore: package name and version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-	"name": "@ainetwork/adk",
-	"version": "0.2.5",
-	"description": "AI Network Agent Development Kit",
-	"repository": "git@github.com:ainetwork-ai/ain-adk.git",
+	"name": "@ainetwork/adk-mission-agent",
+	"version": "1.0.0",
+	"description": "AI Network Mission Agent Development Kit",
+	"repository": "git@github.com:ainetwork-ai/ain-adk-mission-agent.git",
 	"author": "AI Network (https://ainetwork.ai)",
 	"type": "module",
 	"engines": {


### PR DESCRIPTION
mono repo에서 원본 sdk (ain-adk) 와 혼선을 막기 위해 package name 수정합니다.